### PR TITLE
use variable for the pd-lib-builder/ directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,5 @@ class.sources = helloworld.c
 datafiles = helloworld-help.pd helloworld-meta.pd README.md
 
 # include Makefile.pdlibbuilder from submodule directory 'pd-lib-builder'
-include pd-lib-builder/Makefile.pdlibbuilder
+PDLIBBUILDER_DIR=pd-lib-builder/
+include $(PDLIBBUILDER_DIR)/Makefile.pdlibbuilder


### PR DESCRIPTION
the pd-lib-builder directory is a git-submodule.
it will not be preset when downloading a release-tarball or doing a
non-recursive clone.

Closes https://github.com/pure-data/helloworld/issues/2
